### PR TITLE
Several bugfixes and improvements, change from http.request to request

### DIFF
--- a/lib/kairosdb.js
+++ b/lib/kairosdb.js
@@ -90,13 +90,21 @@ KairosDB.prototype.execute = function (endpoint, options, payload, callback) {
       }
       res.setEncoding('utf8');
 
-      if (res.statusCode === 404)
-        return callback(new Error('404: page not found'));
-      else if (res.statusCode === 400) {
-        return callback(new Error('400: server error'));
+      if (res.statusCode === 404) {
+        var e = new Error('404: page not found');
+        e.statusCode = res.statusCode;
+        return callback(e);
       }
-      else if (res.statusCode === 500)
-        return callback(new Error('500: server error'));
+      else if (res.statusCode === 400) {
+        var e = new Error('400: server error');
+        e.statusCode = res.statusCode;
+        return callback(e);
+      }
+      else if (res.statusCode === 500) {
+        var e = new Error('500: server error');
+        e.statusCode = res.statusCode;
+        return callback(e);
+      }
 
       var buffer = '';
       res.on('data', function (chunk) {

--- a/lib/kairosdb.js
+++ b/lib/kairosdb.js
@@ -136,7 +136,7 @@ exports.init = function (host_arg, port_arg, options) {
     host = host_arg || default_host,
     kdb;
 
-  kdb = new KairosDB(port, host, options);
+  kdb = new KairosDB(host, port, options);
 
   kdb.port = port;
   kdb.host = host;

--- a/lib/kairosdb.js
+++ b/lib/kairosdb.js
@@ -1,7 +1,6 @@
 var
   util = require('util'),
   events = require('events'),
-  http = require('http'),
   request = require('request'),
 
   connection_id = 0,
@@ -74,9 +73,7 @@ KairosDB.prototype.execute = function (endpoint, options, payload, callback) {
     method = options.method;
 
   var _options = {
-    host: this.host,
-    port: this.port,
-    path: '/api/' + apiversion + '/' + endpoint,
+    uri: 'http://' + this.host + ':' + this.port + '/api/' + apiversion + '/' + endpoint,
     method: method
   };
   if (options.method === 'POST' && payload) {
@@ -87,12 +84,18 @@ KairosDB.prototype.execute = function (endpoint, options, payload, callback) {
   }
 
   try {
-    var req = http.request(_options, function (res) {
+    if (options.method === 'POST' && payload)
+      _options.body = JSON.stringify(payload);
+    
+    request(_options, function (error, res, body) {
+      if (error) 
+        return callback(error);
+
       if (self.options.debug) {
         console.log('STATUS: ' + res.statusCode);
         console.log('HEADERS: ' + JSON.stringify(res.headers));
+        console.log('BODY: ' + body);
       }
-      res.setEncoding('utf8');
 
       if (res.statusCode === 404) {
         var e = new Error('404: page not found');
@@ -109,33 +112,16 @@ KairosDB.prototype.execute = function (endpoint, options, payload, callback) {
         e.statusCode = res.statusCode;
         return callback(e);
       }
+      else if (res.statusCode === 200) {
+        return callback(null, JSON.parse(body));
+      }
+      else if (res.statusCode === 204) {
+        return callback(null, "");
+      }
+      else
+        return callback(null, body);
 
-      var buffer = '';
-      res.on('data', function (chunk) {
-        if (self.options.debug)
-          console.log('BODY: ' + chunk);
-        buffer += chunk;
-      });
-
-      res.on('end', function () {
-        try {
-          buffer = JSON.parse(buffer);
-        }
-        catch (ex) {
-
-        }
-        return callback(null, buffer);
-      });
     });
-
-    req.on('error', function (err) {
-      return callback(err);
-    });
-
-    if (options.method === 'POST' && payload)
-      req.write(JSON.stringify(payload));
-
-    req.end();
   }
   catch (ex) {
     return callback(ex);

--- a/lib/kairosdb.js
+++ b/lib/kairosdb.js
@@ -88,39 +88,59 @@ KairosDB.prototype.execute = function (endpoint, options, payload, callback) {
       _options.body = JSON.stringify(payload);
     
     request(_options, function (error, res, body) {
-      if (error) 
+      if (error) {
+        if (self.options.debug)
+          console.log(error);
         return callback(error);
-
+      }
+      
       if (self.options.debug) {
         console.log('STATUS: ' + res.statusCode);
         console.log('HEADERS: ' + JSON.stringify(res.headers));
         console.log('BODY: ' + body);
       }
 
-      if (res.statusCode === 404) {
-        var e = new Error('404: page not found');
-        e.statusCode = res.statusCode;
-        return callback(e);
-      }
-      else if (res.statusCode === 400) {
-        var e = new Error('400: server error');
-        e.statusCode = res.statusCode;
-        return callback(e);
-      }
-      else if (res.statusCode === 500) {
-        var e = new Error('500: server error');
-        e.statusCode = res.statusCode;
-        return callback(e);
-      }
-      else if (res.statusCode === 200) {
-        return callback(null, JSON.parse(body));
-      }
-      else if (res.statusCode === 204) {
-        return callback(null, "");
-      }
-      else
-        return callback(null, body);
+      var e = null;
+      var resultObj = null;
 
+      switch (res.statusCode) {
+        case 200:
+          resultObj = JSON.parse(body);
+          break;
+        case 204:
+          resultObj = "";
+          break;
+        case 400:
+          e = new Error('400: Bad Request');
+          break;
+        case 401:
+          e = new Error('401: Unauthorized');
+          break;
+        case 403:
+          e = new Error('403: Forbidden');
+          break;
+        case 404:
+          e = new Error('404: Not Found');
+          break;
+        case 500:
+          e = new Error('500: Internal Server Error');
+          break;
+        case 503:
+          e = new Error('503: Service Unavailable');
+          break;
+        default:
+          resultObj = body;
+          break;
+      }
+
+      if (e) {
+        e.statusCode = res.statusCode;
+        e.body = body;
+        return callback(e);
+      }
+      else {
+        return callback(null, resultObj);
+      }
     });
   }
   catch (ex) {

--- a/lib/kairosdb.js
+++ b/lib/kairosdb.js
@@ -17,7 +17,11 @@ function KairosDB(host, port, options) {
   this.endpoints = [
     ['version', 'GET'],
     ['query', 'POST', 'datapoints'],
-    'datapoints'
+    'datapoints',
+    ['metricnames', 'GET'],
+    ['tagnames', 'GET'],
+    ['tagvalues', 'GET'],
+    ['tags', 'POST', 'datapoints/query']
   ];
 
   this.buildStub();

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "kairosdb",
   "version": "0.0.3",
   "author": "Itay Weinberger <itay@joo.la>",
-  "description": "NodeJS library for communication with KariosDB",
+  "description": "NodeJS library for communication with KairosDB",
   "engine": "node >= 0.10.x",
   "repository": {
     "type": "git",
-    "url": "https://github.com/itayw/kariosdb.git"
+    "url": "https://github.com/itayw/kairosdb.git"
   },
-  "bugs": "https://github.com/itayw/kariosdb/issues",
+  "bugs": "https://github.com/itayw/kairosdb/issues",
   "contributors": [
     {
       "name": "Itay Weinberger",
@@ -37,7 +37,7 @@
   },
   "main": "lib/kairosdb.js",
   "keywords": [
-    "kariosdb",
+    "kairosdb",
     "cassandra"
   ],
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kairosdb",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Itay Weinberger <itay@joo.la>",
   "description": "NodeJS library for communication with KairosDB",
   "engine": "node >= 0.10.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kairosdb",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Itay Weinberger <itay@joo.la>",
   "description": "NodeJS library for communication with KairosDB",
   "engine": "node >= 0.10.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kairosdb",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "Itay Weinberger <itay@joo.la>",
   "description": "NodeJS library for communication with KairosDB",
   "engine": "node >= 0.10.x",

--- a/test/unit/metricnames.spec.js
+++ b/test/unit/metricnames.spec.js
@@ -1,0 +1,16 @@
+var kdb = require('../../lib/kairosdb');
+
+describe("metricnames", function () {
+  it("should get all existing metricnames", function (done) {
+    var client = kdb.init(global.options.host, global.options.port);
+
+    client.metricnames(function (err, metrics) {
+      if (err)
+        return done(err);
+      expect(metrics.results).to.be.ok;
+      metrics = metrics.results;
+      expect(metrics).to.not.be.empty;
+      done();
+    });
+  });
+});

--- a/test/unit/tagnames.spec.js
+++ b/test/unit/tagnames.spec.js
@@ -1,0 +1,16 @@
+var kdb = require('../../lib/kairosdb');
+
+describe("tagnames", function () {
+  it("should get all existing tagnames", function (done) {
+    var client = kdb.init(global.options.host, global.options.port);
+
+    client.tagnames(function (err, tags) {
+      if (err)
+        return done(err);
+      expect(tags.results).to.be.ok;
+      tags = tags.results;
+      expect(tags).to.not.be.empty;
+      done();
+    });
+  });
+});

--- a/test/unit/tags.spec.js
+++ b/test/unit/tags.spec.js
@@ -1,0 +1,38 @@
+var kdb = require('../../lib/kairosdb');
+
+describe("tags", function () {
+  it("should query tags of a given metric", function (done) {
+    var client = kdb.init(global.options.host, global.options.port);
+
+    var data = {
+      "start_relative": {
+        "value": "1",
+        "unit": "years"
+      },
+      "metrics": [
+        {
+          "name": "metric_for_or",                
+          "tags": {
+            "host": ["server2"]
+          }
+        }
+      ]
+    };
+
+    client.tags(data, function (err, metrics) {
+      if (err)
+        return done(err);
+      
+      expect(metrics.queries).to.be.ok;
+      metrics = metrics.queries;
+      expect(metrics).to.not.be.empty;
+      
+      var metric = metrics[0].results[0];
+      expect(metric.tags).to.be.ok;
+      expect(metric.tags).to.have.property("host");
+      expect('server2').to.be.oneOf(metric.tags.host);
+
+      done();
+    });
+  });
+});

--- a/test/unit/tagvalues.spec.js
+++ b/test/unit/tagvalues.spec.js
@@ -1,0 +1,16 @@
+var kdb = require('../../lib/kairosdb');
+
+describe("tagvalues", function () {
+  it("should get all existing tagvalues", function (done) {
+    var client = kdb.init(global.options.host, global.options.port);
+
+    client.tagvalues(function (err, tags) {
+      if (err)
+        return done(err);
+      expect(tags.results).to.be.ok;
+      tags = tags.results;
+      expect(tags).to.not.be.empty;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Hi

I merged several commits from the other forkers altogether. The commits include the following fixes, changes:
- Fix spelling mistake in package.json (#8)
- Fix switched host, port => adapted from @zhuqling
- Change from http.request to [request](https://github.com/request/request) => adapted from @zhuqling
- Add endpoints for metricnames, tagnames, tagvalues and tags => adapted from @zlim
- Add tests for the endpoints above
- Improve error handling
- Change error messages to those of [Wikipedia](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
- Add more error codes (204, 401, 403, 503)